### PR TITLE
patch actor

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -28,6 +28,7 @@
     "tseslint",
     "tshy",
     "uncurried",
+    "unpatch",
     "xstate"
   ],
   "enabledLanguageIds": [

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -1,23 +1,154 @@
-import {type AnyActorRef} from 'xstate';
+import {type AnyActorRef, type Subscription} from 'xstate';
 
-import {type AuditionOptions} from './types.js';
+import {type AuditionOptions, type LoggerFn} from './types.js';
 import {noop} from './util.js';
 
 /**
- * Sets up an existing `ActorRef` with a logger and inspector.
+ * Data stored for each `ActorRef` that has been patched.
  *
- * @param ref `Actor` or `ActorRef`
- * @param options Options for instrumentation
- * @returns Instrumented actor
  * @internal
  */
-export function attachActor(
-  ref: AnyActorRef,
-  {inspector: inspect = noop, logger = noop}: AuditionOptions = {},
-): void {
-  ref.system.inspect(inspect);
+type PatchData = {inspectorSubscription: Subscription; logger: LoggerFn};
 
-  // @ts-expect-error private
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  ref.logger = ref._actorScope.logger = logger;
+/**
+ * A `WeakMap` to store the data for each `ActorRef` that has been patched. Used
+ * by {@link unpatchActor}.
+ *
+ * @internal
+ */
+const patchData = new WeakMap<AnyActorRef, PatchData[]>();
+
+/**
+ * Utility to _mutate_ an existing {@link ActorRef} allowing addition of an
+ * inspector and/or new logger.
+ *
+ * Inspectors are additive, so adding a new inspector is not destructive.
+ * Inspectors are applied across the _entire_ system; there is no way to inspect
+ * only one actor.
+ *
+ * The logger needs to be replaced with a new function that calls the original
+ * logger and the new logger. If the `ActorRef` is a _root_ actor (the one
+ * created via `createActor()`), the logger will be set at the system level;
+ * otherwise it will only be set for the particular Actor.
+ *
+ * **Warning**: If you use this function and plan using {@link unpatchActor},
+ * modifying the `ActorRef`'s logger via external means will result in the loss
+ * of those modifications.
+ *
+ * @remarks
+ * This function is called internally (with its own instrumentation, as
+ * appropriate) by **xstate-audition** on the root `Actor`, and _for every
+ * spawned Actor_. That said, it may be useful otherwise to have granular
+ * control (e.g., when paired with `waitForSpawn()`).
+ * @example
+ *
+ * ```js
+ * const actor = createActor(someLogic);
+ * let childActor = await waitForSpawn(actor, 'childId');
+ * childActor = patchActor(childActor, {
+ *   logger: console.log,
+ *   inspector: console.dir,
+ * });
+ * ```
+ *
+ * @template Actor The type of `ActorRef` to patch
+ * @param actor An `ActorRef` (or `Actor`)
+ * @param options Options
+ * @returns The original `actor`, but modified
+ * @see {@link https://stately.ai/docs/inspection}
+ */
+export function patchActor<Actor extends AnyActorRef>(
+  actor: Actor,
+  {inspector: inspect = noop, logger = noop}: AuditionOptions = {},
+): Actor {
+  const subscription = actor.system.inspect(inspect);
+
+  const data: PatchData[] = patchData.get(actor) ?? [];
+
+  // if there's a reason to prefer a Proxy here, I don't know what it is.
+
+  if (actor._parent) {
+    // @ts-expect-error private
+    const oldLogger = actor.logger as LoggerFn;
+
+    data.push({inspectorSubscription: subscription, logger: oldLogger});
+
+    // in this case, ref.logger should be the same as ref._actorScope.logger
+    // https://github.com/statelyai/xstate/blob/12bde7a3ff47be6bb5a54b03282a77baf76c2bd6/packages/core/src/createActor.ts#L167
+
+    // @ts-expect-error private
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    actor.logger = actor._actorScope.logger = (...args: any[]) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      oldLogger(...args);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      logger(...args);
+    };
+  } else {
+    const oldLogger = actor.system._logger;
+
+    data.push({inspectorSubscription: subscription, logger: oldLogger});
+    // @ts-expect-error private
+    actor.logger =
+      actor.system._logger =
+      // @ts-expect-error private
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      actor._actorScope.logger =
+        (...args: any[]) => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          oldLogger(...args);
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          logger(...args);
+        };
+  }
+  patchData.set(actor, data);
+
+  return actor;
+}
+
+/**
+ * Reverts what was done in {@link patchActor} for a given `ActorRef`. This will
+ * revert _all_ changes to a given `ActorRef` made by `patchActor` _in reverse
+ * order_.
+ *
+ * Mutates `actor`.
+ *
+ * If `actor` has not been patched via `patchActor`, this function returns the
+ * identity.
+ *
+ * **Warning**: If changes were made to the `ActorRef`'s logger by means _other
+ * than_ `patchActor` after the first call to `patchActor` (internally or
+ * otherwise), assume they will be lost.
+ *
+ * @remarks
+ * This function is not currently used internally and is considered
+ * **experimental**. It may be removed in the future if it does not prove to
+ * have a reasonable use-case.
+ * @template Actor The type of the `ActorRef` to unpatch
+ * @param actor `ActorRef` or `Actor` to unpatch
+ * @returns `actor`, but unpatched
+ * @experimental
+ */
+export function unpatchActor<Actor extends AnyActorRef>(actor: Actor): Actor {
+  const data = patchData.get(actor);
+
+  if (!data) {
+    return actor;
+  }
+
+  for (const {inspectorSubscription, logger} of data.reverse()) {
+    inspectorSubscription.unsubscribe();
+    // @ts-expect-error private
+    actor.logger = actor._parent
+      ? // @ts-expect-error private
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (actor._actorScope.logger = logger)
+      : // @ts-expect-error private
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (actor._actorScope.logger = actor.system._logger = logger);
+  }
+
+  patchData.delete(actor);
+
+  return actor;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export * from './actor.js';
+
 export type * from './types.js';
 
 export * from './until-done.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,11 +32,11 @@ export type ActorEventTypeTuple<Actor extends AnyActor> = ReadableArray<
 
 export type AnyActor = xs.AnyActor;
 
-export type AnyListenableActor = xs.Actor<AnyEventReceiverLogic>;
+export type AnyEventReceiverActor = xs.Actor<AnyEventReceiverLogic>;
 
-export type AnyOutputtableActor = xs.Actor<AnyTerminalLogic>;
+export type AnyTerminalActor = xs.Actor<AnyTerminalLogic>;
 
-export type AnySnapshottableActor = xs.Actor<AnySnapshotEmitterLogic>;
+export type AnySnapshotEmitterActor = xs.Actor<AnySnapshotEmitterLogic>;
 
 export type AnyStateMachineActor = xs.Actor<xs.AnyStateMachine>;
 

--- a/src/until-done.ts
+++ b/src/until-done.ts
@@ -1,6 +1,6 @@
 import * as xs from 'xstate';
 
-import {attachActor} from './actor.js';
+import {patchActor} from './actor.js';
 import {applyDefaults} from './defaults.js';
 import {createAbortablePromiseKit} from './promise-kit.js';
 import {startTimer} from './timer.js';
@@ -160,13 +160,13 @@ const untilDone = <
       inspectorObserver.next?.(evt);
 
       if (!seenActors.has(evt.actorRef)) {
-        attachActor(evt.actorRef, {logger});
+        patchActor(evt.actorRef, {logger});
         seenActors.add(evt.actorRef);
       }
     },
   };
 
-  attachActor(actor, {...opts, inspector: doneInspector});
+  patchActor(actor, {...opts, inspector: doneInspector});
   seenActors.add(actor);
 
   // order is important: create promise, then start.

--- a/src/until-done.ts
+++ b/src/until-done.ts
@@ -5,48 +5,48 @@ import {applyDefaults} from './defaults.js';
 import {createAbortablePromiseKit} from './promise-kit.js';
 import {startTimer} from './timer.js';
 import {
-  type AnyOutputtableActor,
+  type AnyTerminalActor,
   type AuditionOptions,
   type InternalAuditionOptions,
 } from './types.js';
 
 export type CurryDone =
   | (() => CurryDone)
-  | (<Actor extends AnyOutputtableActor, Output extends xs.OutputFrom<Actor>>(
+  | (<Actor extends AnyTerminalActor, Output extends xs.OutputFrom<Actor>>(
       actor: Actor,
     ) => CurryDoneP1<Actor, Output>);
 
 export type CurryDoneP1<
-  Actor extends AnyOutputtableActor,
+  Actor extends AnyTerminalActor,
   Output extends xs.OutputFrom<Actor>,
 > = Promise<Output>;
 
 export type CurryDoneWith =
   | (() => CurryDoneWith)
-  | (<Actor extends AnyOutputtableActor, Output extends xs.OutputFrom<Actor>>(
+  | (<Actor extends AnyTerminalActor, Output extends xs.OutputFrom<Actor>>(
       actor: Actor,
       options: AuditionOptions,
     ) => CurryDoneWithP2<Actor, Output>)
-  | (<Actor extends AnyOutputtableActor, Output extends xs.OutputFrom<Actor>>(
+  | (<Actor extends AnyTerminalActor, Output extends xs.OutputFrom<Actor>>(
       actor: Actor,
     ) => CurryDoneWithP1<Actor, Output>);
 
 export type CurryDoneWithP1<
-  Actor extends AnyOutputtableActor,
+  Actor extends AnyTerminalActor,
   Output extends xs.OutputFrom<Actor>,
 > =
   | (() => CurryDoneWithP1<Actor, Output>)
   | ((options: AuditionOptions) => CurryDoneWithP2<Actor, Output>);
 
 export type CurryDoneWithP2<
-  Actor extends AnyOutputtableActor,
+  Actor extends AnyTerminalActor,
   Output extends xs.OutputFrom<Actor>,
 > = Promise<Output>;
 
 export function runUntilDone(): CurryDone;
 
 export function runUntilDone<
-  Actor extends AnyOutputtableActor,
+  Actor extends AnyTerminalActor,
   Output extends xs.OutputFrom<Actor>,
 >(actor: Actor): CurryDoneP1<Actor, Output>;
 
@@ -60,24 +60,24 @@ export function runUntilDone<
  * @param actorRef An existing {@link Actor}
  * @returns `Promise` fulfilling with the actor output
  */
-export function runUntilDone<Actor extends AnyOutputtableActor>(actor?: Actor) {
+export function runUntilDone<Actor extends AnyTerminalActor>(actor?: Actor) {
   return runUntilDone_(actor);
 }
 
 export function runUntilDoneWith(): CurryDoneWith;
 
 export function runUntilDoneWith<
-  Actor extends AnyOutputtableActor,
+  Actor extends AnyTerminalActor,
   Output extends xs.OutputFrom<Actor>,
 >(actor: Actor): CurryDoneWithP1<Actor, Output>;
 
 export function runUntilDoneWith<
-  Actor extends AnyOutputtableActor,
+  Actor extends AnyTerminalActor,
   Output extends xs.OutputFrom<Actor>,
 >(actor: Actor, options: AuditionOptions): CurryDoneWithP2<Actor, Output>;
 
 export function runUntilDoneWith<
-  Actor extends AnyOutputtableActor,
+  Actor extends AnyTerminalActor,
   Output extends xs.OutputFrom<Actor>,
 >(actor?: Actor, options?: AuditionOptions) {
   return runUntilDoneWith_<Actor, Output>(actor, options);
@@ -85,7 +85,7 @@ export function runUntilDoneWith<
 
 const createDoneFn = () => {
   const curryDone = <
-    Actor extends AnyOutputtableActor,
+    Actor extends AnyTerminalActor,
     Output extends xs.OutputFrom<Actor>,
   >(
     actor?: Actor,
@@ -102,7 +102,7 @@ const createDoneFn = () => {
 
 const createDoneWithFn = () => {
   const curryDoneWith = <
-    Actor extends AnyOutputtableActor,
+    Actor extends AnyTerminalActor,
     Output extends xs.OutputFrom<Actor>,
   >(
     actor?: Actor,
@@ -129,7 +129,7 @@ const createDoneWithFn = () => {
 };
 
 const untilDone = <
-  Actor extends AnyOutputtableActor,
+  Actor extends AnyTerminalActor,
   Output extends xs.OutputFrom<Actor>,
 >(
   actor: Actor,

--- a/src/until-emitted.ts
+++ b/src/until-emitted.ts
@@ -1,6 +1,6 @@
 import * as xs from 'xstate';
 
-import {attachActor} from './actor.js';
+import {patchActor} from './actor.js';
 import {applyDefaults} from './defaults.js';
 import {createAbortablePromiseKit} from './promise-kit.js';
 import {startTimer} from './timer.js';
@@ -311,7 +311,7 @@ const untilEmitted = async <
     next: (evt) => {
       inspectorObserver.next?.(evt);
       if (!seenActors.has(evt.actorRef)) {
-        attachActor(evt.actorRef, {logger});
+        patchActor(evt.actorRef, {logger});
         seenActors.add(evt.actorRef);
       }
     },
@@ -352,7 +352,7 @@ const untilEmitted = async <
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const emitted: ActorEmittedTuple<Actor, EmittedTypes> = [] as any;
 
-  attachActor(actor, {...opts, inspector: emittedInspector});
+  patchActor(actor, {...opts, inspector: emittedInspector});
 
   let eventSubscription = subscribe(expectedEventQueue.shift());
 

--- a/src/until-event-received.ts
+++ b/src/until-event-received.ts
@@ -7,7 +7,7 @@ import {startTimer} from './timer.js';
 import {
   type ActorEventTuple,
   type ActorEventTypeTuple,
-  type AnyListenableActor,
+  type AnyEventReceiverActor,
   type AuditionEventOptions,
   type AuditionOptions,
   type EventFromEventType,
@@ -17,45 +17,45 @@ import {head} from './util.js';
 
 export type CurryEventReceived = (() => CurryEventReceived) &
   (<
-    Actor extends AnyListenableActor,
+    Actor extends AnyEventReceiverActor,
     const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
   >(
     actor: Actor,
     eventTypes: EventReceivedTypes,
   ) => CurryEventReceivedP2<Actor, EventReceivedTypes>) &
-  (<Actor extends AnyListenableActor>(
+  (<Actor extends AnyEventReceiverActor>(
     actor: Actor,
   ) => CurryEventReceivedP1<Actor>);
 
-export type CurryEventReceivedP1<Actor extends AnyListenableActor> =
+export type CurryEventReceivedP1<Actor extends AnyEventReceiverActor> =
   (() => CurryEventReceivedP1<Actor>) &
     (<const EventReceivedTypes extends ActorEventTypeTuple<Actor>>(
       eventTypes: EventReceivedTypes,
     ) => CurryEventReceivedP2<Actor, EventReceivedTypes>);
 
 export type CurryEventReceivedP2<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 > = Promise<ActorEventTuple<Actor, EventReceivedTypes>>;
 
 export type CurryEventReceivedWith = (() => CurryEventReceivedWith) &
   (<
-    Actor extends AnyListenableActor,
+    Actor extends AnyEventReceiverActor,
     const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
   >(
     actor: Actor,
     options: AuditionOptions,
     eventTypes: EventReceivedTypes,
   ) => CurryEventReceivedWithP3<Actor, EventReceivedTypes>) &
-  (<Actor extends AnyListenableActor>(
+  (<Actor extends AnyEventReceiverActor>(
     actor: Actor,
     options: AuditionEventOptions,
   ) => CurryEventReceivedWithP2<Actor>) &
-  (<Actor extends AnyListenableActor>(
+  (<Actor extends AnyEventReceiverActor>(
     actor: Actor,
   ) => CurryEventReceivedWithP1<Actor>);
 
-export type CurryEventReceivedWithP1<Actor extends AnyListenableActor> =
+export type CurryEventReceivedWithP1<Actor extends AnyEventReceiverActor> =
   (() => CurryEventReceivedWithP1<Actor>) &
     ((options: AuditionEventOptions) => CurryEventReceivedWithP2<Actor>) &
     (<const EventReceivedTypes extends ActorEventTypeTuple<Actor>>(
@@ -63,14 +63,14 @@ export type CurryEventReceivedWithP1<Actor extends AnyListenableActor> =
       eventTypes: EventReceivedTypes,
     ) => CurryEventReceivedWithP3<Actor, EventReceivedTypes>);
 
-export type CurryEventReceivedWithP2<Actor extends AnyListenableActor> =
+export type CurryEventReceivedWithP2<Actor extends AnyEventReceiverActor> =
   (() => CurryEventReceivedWithP2<Actor>) &
     (<const EventReceivedTypes extends ActorEventTypeTuple<Actor>>(
       eventTypes: EventReceivedTypes,
     ) => CurryEventReceivedWithP3<Actor, EventReceivedTypes>);
 
 export type CurryEventReceivedWithP3<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 > = Promise<ActorEventTuple<Actor, EventReceivedTypes>>;
 
@@ -86,7 +86,7 @@ export type CurryEventReceivedWithP3<
  *   occurred in order)
  */
 export function runUntilEventReceived<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 >(
   actor: Actor,
@@ -102,7 +102,7 @@ export function runUntilEventReceived<
  * @returns A function which runs an actor until it sends one or more events (in
  *   order)
  */
-export function runUntilEventReceived<Actor extends AnyListenableActor>(
+export function runUntilEventReceived<Actor extends AnyEventReceiverActor>(
   actor: Actor,
 ): CurryEventReceivedP1<Actor>;
 
@@ -114,7 +114,7 @@ export function runUntilEventReceived<Actor extends AnyListenableActor>(
 export function runUntilEventReceived(): CurryEventReceived;
 
 export function runUntilEventReceived<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 >(actor?: Actor, events?: EventReceivedTypes) {
   return runUntilEventReceived_(actor, events);
@@ -122,17 +122,17 @@ export function runUntilEventReceived<
 
 export function runUntilEventReceivedWith(): CurryEventReceivedWith;
 
-export function runUntilEventReceivedWith<Actor extends AnyListenableActor>(
+export function runUntilEventReceivedWith<Actor extends AnyEventReceiverActor>(
   actor: Actor,
 ): CurryEventReceivedWithP1<Actor>;
 
-export function runUntilEventReceivedWith<Actor extends AnyListenableActor>(
+export function runUntilEventReceivedWith<Actor extends AnyEventReceiverActor>(
   actor: Actor,
   options: AuditionEventOptions,
 ): CurryEventReceivedWithP2<Actor>;
 
 export function runUntilEventReceivedWith<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 >(
   actor: Actor,
@@ -141,7 +141,7 @@ export function runUntilEventReceivedWith<
 ): CurryEventReceivedWithP3<Actor, EventReceivedTypes>;
 
 export function runUntilEventReceivedWith<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 >(actor?: Actor, options?: AuditionOptions, events?: EventReceivedTypes) {
   return runUntilEventReceivedWith_(actor, options, events);
@@ -149,12 +149,12 @@ export function runUntilEventReceivedWith<
 
 export function waitForEventReceived(): CurryEventReceived;
 
-export function waitForEventReceived<Actor extends AnyListenableActor>(
+export function waitForEventReceived<Actor extends AnyEventReceiverActor>(
   actor: Actor,
 ): CurryEventReceivedP1<Actor>;
 
 export function waitForEventReceived<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 >(
   actor: Actor,
@@ -162,7 +162,7 @@ export function waitForEventReceived<
 ): CurryEventReceivedP2<Actor, EventReceivedTypes>;
 
 export function waitForEventReceived<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 >(actor?: Actor, events?: EventReceivedTypes) {
   return waitForEventReceived_(actor, events);
@@ -187,7 +187,7 @@ export function waitForEventReceivedWith(): CurryEventReceivedWith;
  *   {@link ActorEventTypeTuple event types}, will waits until an XState `Actor`
  *   receives one or more events (in order).
  */
-export function waitForEventReceivedWith<Actor extends AnyListenableActor>(
+export function waitForEventReceivedWith<Actor extends AnyEventReceiverActor>(
   actor: Actor,
 ): CurryEventReceivedWithP1<Actor>;
 
@@ -202,7 +202,7 @@ export function waitForEventReceivedWith<Actor extends AnyListenableActor>(
  * @returns A `Promise` fulfilling with the matching events (assuming they all
  *   occurred in order)
  */
-export function waitForEventReceivedWith<Actor extends AnyListenableActor>(
+export function waitForEventReceivedWith<Actor extends AnyEventReceiverActor>(
   actor: Actor,
   options: AuditionEventOptions,
 ): CurryEventReceivedWithP2<Actor>;
@@ -221,7 +221,7 @@ export function waitForEventReceivedWith<Actor extends AnyListenableActor>(
  *   occurred in order)
  */
 export function waitForEventReceivedWith<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 >(
   actor: Actor,
@@ -230,7 +230,7 @@ export function waitForEventReceivedWith<
 ): CurryEventReceivedWithP3<Actor, EventReceivedTypes>;
 
 export function waitForEventReceivedWith<
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 >(actor?: Actor, options?: AuditionOptions, events?: EventReceivedTypes) {
   return waitForEventReceivedWith_(actor, options, events);
@@ -238,7 +238,7 @@ export function waitForEventReceivedWith<
 
 const createEventFn = (stop = false) => {
   const curryEvent = <
-    Actor extends AnyListenableActor,
+    Actor extends AnyEventReceiverActor,
     const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
   >(
     actor?: Actor,
@@ -263,7 +263,7 @@ const createEventFn = (stop = false) => {
 
 const createEventReceivedWithFn = (stop = false) => {
   const curryEventReceivedWith = <
-    Actor extends AnyListenableActor,
+    Actor extends AnyEventReceiverActor,
     const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
   >(
     actor?: Actor,
@@ -308,7 +308,7 @@ const createEventReceivedWithFn = (stop = false) => {
 };
 
 const untilEventReceived = async <
-  Actor extends AnyListenableActor,
+  Actor extends AnyEventReceiverActor,
   const EventReceivedTypes extends ActorEventTypeTuple<Actor>,
 >(
   actor: Actor,

--- a/src/until-event-received.ts
+++ b/src/until-event-received.ts
@@ -1,6 +1,6 @@
 import * as xs from 'xstate';
 
-import {attachActor} from './actor.js';
+import {patchActor} from './actor.js';
 import {applyDefaults} from './defaults.js';
 import {createAbortablePromiseKit} from './promise-kit.js';
 import {startTimer} from './timer.js';
@@ -382,7 +382,7 @@ const untilEventReceived = async <
       inspectorObserver.next?.(evt);
 
       if (!seenActors.has(evt.actorRef)) {
-        attachActor(evt.actorRef, {logger});
+        patchActor(evt.actorRef, {logger});
         seenActors.add(evt.actorRef);
       }
 
@@ -413,7 +413,7 @@ const untilEventReceived = async <
     },
   };
 
-  attachActor(actor, {...opts, inspector: eventReceivedInspector});
+  patchActor(actor, {...opts, inspector: eventReceivedInspector});
   seenActors.add(actor);
 
   const expectedEventQueue = [...eventTypes];

--- a/src/until-event-sent.ts
+++ b/src/until-event-sent.ts
@@ -8,7 +8,7 @@ import {
   type ActorEventTuple,
   type ActorEventTypeTuple,
   type AnyActor,
-  type AnyListenableActor,
+  type AnyEventReceiverActor,
   type AuditionEventOptions,
   type EventFromEventType,
   type InternalAuditionEventOptions,
@@ -18,7 +18,7 @@ import {head} from './util.js';
 export type CurryEventSent = (() => CurryEventSent) &
   (<
     Actor extends AnyActor,
-    Target extends AnyListenableActor = AnyListenableActor,
+    Target extends AnyEventReceiverActor = AnyEventReceiverActor,
     const EventSentTypes extends
       ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
   >(
@@ -29,7 +29,7 @@ export type CurryEventSent = (() => CurryEventSent) &
 
 export type CurryEventSentP1<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
 > = (() => CurryEventSentP1<Actor, Target>) &
   (<
     const EventSentTypes extends
@@ -39,7 +39,7 @@ export type CurryEventSentP1<
   ) => CurryEventSentP2<Target, EventSentTypes>);
 
 export type CurryEventSentP2<
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 > = Promise<ActorEventTuple<Target, EventSentTypes>>;
@@ -47,7 +47,7 @@ export type CurryEventSentP2<
 export type CurryEventSentWith = (() => CurryEventSentWith) &
   (<
     Actor extends AnyActor,
-    Target extends AnyListenableActor = AnyListenableActor,
+    Target extends AnyEventReceiverActor = AnyEventReceiverActor,
     const EventSentTypes extends
       ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
   >(
@@ -57,7 +57,7 @@ export type CurryEventSentWith = (() => CurryEventSentWith) &
   ) => CurryEventSentWithP3<Target, EventSentTypes>) &
   (<
     Actor extends AnyActor,
-    Target extends AnyListenableActor = AnyListenableActor,
+    Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   >(
     actor: Actor,
     options: AuditionEventOptions,
@@ -68,7 +68,7 @@ export type CurryEventSentWithP1<Actor extends AnyActor> =
   (() => CurryEventSentWithP1<Actor>) &
     ((options: AuditionEventOptions) => CurryEventSentWithP2<Actor>) &
     (<
-      Target extends AnyListenableActor = AnyListenableActor,
+      Target extends AnyEventReceiverActor = AnyEventReceiverActor,
       const EventSentTypes extends
         ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
     >(
@@ -78,7 +78,7 @@ export type CurryEventSentWithP1<Actor extends AnyActor> =
 
 export type CurryEventSentWithP2<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
 > = (() => CurryEventSentWithP2<Actor, Target>) &
   (<
     const EventSentTypes extends
@@ -88,7 +88,7 @@ export type CurryEventSentWithP2<
   ) => CurryEventSentWithP3<Target, EventSentTypes>);
 
 export type CurryEventSentWithP3<
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 > = Promise<ActorEventTuple<Target, EventSentTypes>>;
@@ -105,12 +105,12 @@ export function runUntilEventSent(): CurryEventSent;
 
 export function runUntilEventSent<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
 >(actor: Actor): CurryEventSentP1<Actor, Target>;
 
 export function runUntilEventSent<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   const EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 >(
@@ -120,7 +120,7 @@ export function runUntilEventSent<
 
 export function runUntilEventSent<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   const EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 >(actor?: Actor, eventTypes?: EventSentTypes) {
@@ -140,7 +140,7 @@ export function runUntilEventSentWith<Actor extends AnyActor>(
 
 export function runUntilEventSentWith<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   const EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 >(
@@ -151,7 +151,7 @@ export function runUntilEventSentWith<
 
 export function runUntilEventSentWith<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   const EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 >(actor?: Actor, options?: AuditionEventOptions, events?: EventSentTypes) {
@@ -166,7 +166,7 @@ export function waitForEventSent<Actor extends AnyActor>(
 
 export function waitForEventSent<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   const EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 >(
@@ -176,7 +176,7 @@ export function waitForEventSent<
 
 export function waitForEventSent<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   const EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 >(actor?: Actor, events?: EventSentTypes) {
@@ -206,7 +206,7 @@ export function waitForEventSentWith<Actor extends AnyActor>(
 
 export function waitForEventSentWith<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   const EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 >(
@@ -217,7 +217,7 @@ export function waitForEventSentWith<
 
 export function waitForEventSentWith<
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   const EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 >(actor?: Actor, options?: AuditionEventOptions, events?: EventSentTypes) {
@@ -227,7 +227,7 @@ export function waitForEventSentWith<
 const createEventFn = (stop = false) => {
   const curryEvent = <
     Actor extends AnyActor,
-    Target extends AnyListenableActor = AnyListenableActor,
+    Target extends AnyEventReceiverActor = AnyEventReceiverActor,
     const EventSentTypes extends
       ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
   >(
@@ -254,7 +254,7 @@ const createEventFn = (stop = false) => {
 const createEventSentWithFn = (stop = false) => {
   const curryEventSentWith = <
     Actor extends AnyActor,
-    Target extends AnyListenableActor = AnyListenableActor,
+    Target extends AnyEventReceiverActor = AnyEventReceiverActor,
     const EventSentTypes extends
       ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
   >(
@@ -301,7 +301,7 @@ const createEventSentWithFn = (stop = false) => {
 
 const untilEventSent = async <
   Actor extends AnyActor,
-  Target extends AnyListenableActor = AnyListenableActor,
+  Target extends AnyEventReceiverActor = AnyEventReceiverActor,
   const EventSentTypes extends
     ActorEventTypeTuple<Target> = ActorEventTypeTuple<Target>,
 >(

--- a/src/until-event-sent.ts
+++ b/src/until-event-sent.ts
@@ -1,6 +1,6 @@
 import * as xs from 'xstate';
 
-import {attachActor} from './actor.js';
+import {patchActor} from './actor.js';
 import {applyDefaults} from './defaults.js';
 import {createAbortablePromiseKit} from './promise-kit.js';
 import {startTimer} from './timer.js';
@@ -376,7 +376,7 @@ const untilEventSent = async <
       inspectorObserver.next?.(evt);
 
       if (!seenActors.has(evt.actorRef)) {
-        attachActor(evt.actorRef, {logger});
+        patchActor(evt.actorRef, {logger});
         seenActors.add(evt.actorRef);
       }
 
@@ -404,7 +404,7 @@ const untilEventSent = async <
     },
   };
 
-  attachActor(actor, {...opts, inspector: eventSentInspector});
+  patchActor(actor, {...opts, inspector: eventSentInspector});
   seenActors.add(actor);
 
   const expectedEventQueue = [...eventTypes];

--- a/src/until-snapshot.ts
+++ b/src/until-snapshot.ts
@@ -3,8 +3,8 @@ import * as xs from 'xstate';
 import {attachActor} from './actor.js';
 import {applyDefaults} from './defaults.js';
 import {
+  type AnySnapshotEmitterActor,
   type AnySnapshotEmitterLogic,
-  type AnySnapshottableActor,
   type AuditionOptions,
   type InternalAuditionOptions,
 } from './types.js';
@@ -12,38 +12,38 @@ import {
 export type {AnySnapshotEmitterLogic as ActorLogicWithSnapshot};
 
 export type CurrySnapshot = (() => CurrySnapshot) &
-  (<Actor extends AnySnapshottableActor>(
+  (<Actor extends AnySnapshotEmitterActor>(
     actor: Actor,
     predicate: SnapshotPredicate<Actor['logic']>,
   ) => CurrySnapshotP2<Actor>) &
-  (<Actor extends AnySnapshottableActor>(
+  (<Actor extends AnySnapshotEmitterActor>(
     actor: Actor,
   ) => CurrySnapshotP1<Actor>);
 
-export type CurrySnapshotP1<Actor extends AnySnapshottableActor> =
+export type CurrySnapshotP1<Actor extends AnySnapshotEmitterActor> =
   (() => CurrySnapshotP1<Actor>) &
     ((predicate: SnapshotPredicate<Actor['logic']>) => CurrySnapshotP2<Actor>);
 
-export type CurrySnapshotP2<Actor extends AnySnapshottableActor> = Promise<
+export type CurrySnapshotP2<Actor extends AnySnapshotEmitterActor> = Promise<
   xs.SnapshotFrom<Actor['logic']>
 >;
 
 export type CurrySnapshotWith = (() => CurrySnapshotWith) &
-  (<Actor extends AnySnapshottableActor>(
+  (<Actor extends AnySnapshotEmitterActor>(
     actor: Actor,
     predicate: SnapshotPredicate<Actor['logic']>,
     options: AuditionOptions,
   ) => CurrySnapshotWithP3<Actor>) &
-  (<Actor extends AnySnapshottableActor>(
+  (<Actor extends AnySnapshotEmitterActor>(
     actor: Actor,
     predicate: SnapshotPredicate<Actor['logic']>,
   ) => CurrySnapshotWithP2<Actor>) &
-  (<Actor extends AnySnapshottableActor>(
+  (<Actor extends AnySnapshotEmitterActor>(
     actor: Actor,
   ) => CurrySnapshotWithP1<Actor>);
 
 // prettier-ignore
-export type CurrySnapshotWithP1<Actor extends AnySnapshottableActor> = ((
+export type CurrySnapshotWithP1<Actor extends AnySnapshotEmitterActor> = ((
     predicate: SnapshotPredicate<Actor['logic']>,
   ) => CurrySnapshotWithP2<Actor>) &
   ((
@@ -52,13 +52,12 @@ export type CurrySnapshotWithP1<Actor extends AnySnapshottableActor> = ((
 ) => CurrySnapshotWithP3<Actor>) &
   (() => CurrySnapshotWithP1<Actor>);
 
-export type CurrySnapshotWithP2<Actor extends AnySnapshottableActor> =
+export type CurrySnapshotWithP2<Actor extends AnySnapshotEmitterActor> =
   (() => CurrySnapshotWithP2<Actor>) &
     ((options: AuditionOptions) => CurrySnapshotWithP3<Actor>);
 
-export type CurrySnapshotWithP3<Actor extends AnySnapshottableActor> = Promise<
-  xs.SnapshotFrom<Actor['logic']>
->;
+export type CurrySnapshotWithP3<Actor extends AnySnapshotEmitterActor> =
+  Promise<xs.SnapshotFrom<Actor['logic']>>;
 
 export type SnapshotPredicate<T extends AnySnapshotEmitterLogic> = (
   snapshot: xs.SnapshotFrom<T>,
@@ -76,16 +75,16 @@ export type SnapshotPredicate<T extends AnySnapshotEmitterLogic> = (
  */
 export function runUntilSnapshot(): CurrySnapshot;
 
-export function runUntilSnapshot<Actor extends AnySnapshottableActor>(
+export function runUntilSnapshot<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
 ): CurrySnapshotP1<Actor>;
 
-export function runUntilSnapshot<Actor extends AnySnapshottableActor>(
+export function runUntilSnapshot<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
   predicate: SnapshotPredicate<Actor['logic']>,
 ): CurrySnapshotP2<Actor>;
 
-export function runUntilSnapshot<Actor extends AnySnapshottableActor>(
+export function runUntilSnapshot<Actor extends AnySnapshotEmitterActor>(
   actor?: Actor,
   predicate?: SnapshotPredicate<Actor['logic']>,
 ) {
@@ -105,22 +104,22 @@ export function runUntilSnapshot<Actor extends AnySnapshottableActor>(
  */
 export function runUntilSnapshotWith(): CurrySnapshotWith;
 
-export function runUntilSnapshotWith<Actor extends AnySnapshottableActor>(
+export function runUntilSnapshotWith<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
 ): CurrySnapshotWithP1<Actor>;
 
-export function runUntilSnapshotWith<Actor extends AnySnapshottableActor>(
+export function runUntilSnapshotWith<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
   options: AuditionOptions,
 ): CurrySnapshotWithP2<Actor>;
 
-export function runUntilSnapshotWith<Actor extends AnySnapshottableActor>(
+export function runUntilSnapshotWith<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
   options: AuditionOptions,
   predicate: SnapshotPredicate<Actor['logic']>,
 ): CurrySnapshotWithP3<Actor>;
 
-export function runUntilSnapshotWith<Actor extends AnySnapshottableActor>(
+export function runUntilSnapshotWith<Actor extends AnySnapshotEmitterActor>(
   actor?: Actor,
   options?: AuditionOptions,
   predicate?: SnapshotPredicate<Actor['logic']>,
@@ -130,16 +129,16 @@ export function runUntilSnapshotWith<Actor extends AnySnapshottableActor>(
 
 export function waitForSnapshot(): CurrySnapshot;
 
-export function waitForSnapshot<Actor extends AnySnapshottableActor>(
+export function waitForSnapshot<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
 ): CurrySnapshotP1<Actor>;
 
-export function waitForSnapshot<Actor extends AnySnapshottableActor>(
+export function waitForSnapshot<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
   predicate?: SnapshotPredicate<Actor['logic']>,
 ): CurrySnapshotP2<Actor>;
 
-export function waitForSnapshot<Actor extends AnySnapshottableActor>(
+export function waitForSnapshot<Actor extends AnySnapshotEmitterActor>(
   actor?: Actor,
   predicate?: SnapshotPredicate<Actor['logic']>,
 ) {
@@ -148,22 +147,22 @@ export function waitForSnapshot<Actor extends AnySnapshottableActor>(
 
 export function waitForSnapshotWith(): CurrySnapshotWith;
 
-export function waitForSnapshotWith<Actor extends AnySnapshottableActor>(
+export function waitForSnapshotWith<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
 ): CurrySnapshotWithP1<Actor>;
 
-export function waitForSnapshotWith<Actor extends AnySnapshottableActor>(
+export function waitForSnapshotWith<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
   options: AuditionOptions,
 ): CurrySnapshotWithP2<Actor>;
 
-export function waitForSnapshotWith<Actor extends AnySnapshottableActor>(
+export function waitForSnapshotWith<Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
   options: AuditionOptions,
   predicate: SnapshotPredicate<Actor['logic']>,
 ): CurrySnapshotWithP3<Actor>;
 
-export function waitForSnapshotWith<Actor extends AnySnapshottableActor>(
+export function waitForSnapshotWith<Actor extends AnySnapshotEmitterActor>(
   actor?: Actor,
   options?: AuditionOptions,
   predicate?: SnapshotPredicate<Actor['logic']>,
@@ -171,7 +170,7 @@ export function waitForSnapshotWith<Actor extends AnySnapshottableActor>(
   return waitForSnapshotWith_(actor, options, predicate);
 }
 
-const untilSnapshot = <Actor extends AnySnapshottableActor>(
+const untilSnapshot = <Actor extends AnySnapshotEmitterActor>(
   actor: Actor,
   options: InternalAuditionOptions,
   predicate: SnapshotPredicate<Actor['logic']>,
@@ -232,7 +231,7 @@ const untilSnapshot = <Actor extends AnySnapshottableActor>(
 };
 
 const createSnapshotFn = (stop = false) => {
-  const currySnapshot = <Actor extends AnySnapshottableActor>(
+  const currySnapshot = <Actor extends AnySnapshotEmitterActor>(
     actor?: Actor,
     predicate?: SnapshotPredicate<Actor['logic']>,
   ) => {
@@ -260,7 +259,7 @@ const createSnapshotFn = (stop = false) => {
 };
 
 const createSnapshotWithFn = (stop = false) => {
-  const currySnapshotWith = <Actor extends AnySnapshottableActor>(
+  const currySnapshotWith = <Actor extends AnySnapshotEmitterActor>(
     actor?: Actor,
     options?: AuditionOptions,
     predicate?: SnapshotPredicate<Actor['logic']>,

--- a/src/until-snapshot.ts
+++ b/src/until-snapshot.ts
@@ -1,6 +1,6 @@
 import * as xs from 'xstate';
 
-import {attachActor} from './actor.js';
+import {patchActor} from './actor.js';
 import {applyDefaults} from './defaults.js';
 import {
   type AnySnapshotEmitterActor,
@@ -189,13 +189,13 @@ const untilSnapshot = <Actor extends AnySnapshotEmitterActor>(
     next: (evt) => {
       inspectorObserver.next?.(evt);
       if (!seenActors.has(evt.actorRef)) {
-        attachActor(evt.actorRef, {logger});
+        patchActor(evt.actorRef, {logger});
         seenActors.add(evt.actorRef);
       }
     },
   };
 
-  attachActor(actor, {...opts, inspector: snapshotInspector});
+  patchActor(actor, {...opts, inspector: snapshotInspector});
   seenActors.add(actor);
 
   const promise = xs

--- a/src/until-spawn.ts
+++ b/src/until-spawn.ts
@@ -1,6 +1,6 @@
 import * as xs from 'xstate';
 
-import {attachActor} from './actor.js';
+import {patchActor} from './actor.js';
 import {applyDefaults} from './defaults.js';
 import {createAbortablePromiseKit} from './promise-kit.js';
 import {startTimer} from './timer.js';
@@ -255,7 +255,7 @@ const untilSpawn = async <Logic extends xs.AnyActorLogic>(
       inspectorObserver.next?.(evt);
 
       if (!seenActors.has(evt.actorRef)) {
-        attachActor(evt.actorRef, {logger});
+        patchActor(evt.actorRef, {logger});
         seenActors.add(evt.actorRef);
       }
 
@@ -270,7 +270,7 @@ const untilSpawn = async <Logic extends xs.AnyActorLogic>(
     },
   };
 
-  attachActor(actor, {...opts, inspector: spawnInspector});
+  patchActor(actor, {...opts, inspector: spawnInspector});
   seenActors.add(actor);
   startTimer(
     actor,

--- a/src/until-transition.ts
+++ b/src/until-transition.ts
@@ -1,6 +1,6 @@
 import * as xs from 'xstate';
 
-import {attachActor} from './actor.js';
+import {patchActor} from './actor.js';
 import {applyDefaults} from './defaults.js';
 import {createAbortablePromiseKit} from './promise-kit.js';
 import {startTimer} from './timer.js';
@@ -382,7 +382,7 @@ const untilTransition = <Actor extends AnyStateMachineActor>(
       inspectorObserver.next?.(evt);
 
       if (!seenActors.has(evt.actorRef)) {
-        attachActor(evt.actorRef, {logger});
+        patchActor(evt.actorRef, {logger});
         seenActors.add(evt.actorRef);
       }
 
@@ -403,7 +403,7 @@ const untilTransition = <Actor extends AnyStateMachineActor>(
     },
   };
 
-  attachActor(actor, {
+  patchActor(actor, {
     ...opts,
     inspector: transitionInspector,
   });


### PR DESCRIPTION
`patchActor` is a utility to mutate an existing `ActorRef` allowing addition of an inspector and/or new logger.

Inspectors are additive, so adding a new inspector is not destructive.

The logger needs to be replaced with a new function that calls the original logger and the new logger. If the `ActorRef` is a the root actor, the logger will be set at the system level; otherwise it will only be set for the particular `ActorRef`. This diverges from XState's behavior, which currently intends to only support a system-level logger.

The new `unpatchActor()` is an experimental API available to undo the changes made in `patchActor()`.

---

**xstate-audition** will no longer destroy an Actor's existing logger; it will now compose loggers correctly.
